### PR TITLE
Return slices and maps without indirection

### DIFF
--- a/meters.go
+++ b/meters.go
@@ -41,11 +41,11 @@ type MeterAggregatesData struct {
 // to/from each category of connection ("site", "solar", "battery", "load", etc).
 //
 // See the MetersAggregatesData type for more information on what fields this returns.
-func (c *Client) GetMetersAggregates() (*map[string]MeterAggregatesData, error) {
+func (c *Client) GetMetersAggregates() (map[string]MeterAggregatesData, error) {
 	c.checkLogin()
 	result := map[string]MeterAggregatesData{}
 	err := c.apiGetJson("meters/aggregates", &result)
-	return &result, err
+	return result, err
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -111,9 +111,9 @@ type MeterData struct {
 // this will return nil.
 //
 // See the MeterData type for more information on what fields this returns.
-func (c *Client) GetMeters(category string) (*[]MeterData, error) {
+func (c *Client) GetMeters(category string) ([]MeterData, error) {
 	c.checkLogin()
 	result := []MeterData{}
 	err := c.apiGetJson("meters/"+url.PathEscape(category), &result)
-	return &result, err
+	return result, err
 }

--- a/networks.go
+++ b/networks.go
@@ -44,9 +44,9 @@ type NetworkData struct {
 // system, and their statuses.
 //
 // See the NetworkData type for more information on what fields this returns.
-func (c *Client) GetNetworks() (*[]NetworkData, error) {
+func (c *Client) GetNetworks() ([]NetworkData, error) {
 	c.checkLogin()
 	result := []NetworkData{}
 	err := c.apiGetJson("networks", &result)
-	return &result, err
+	return result, err
 }

--- a/system.go
+++ b/system.go
@@ -113,11 +113,11 @@ type GridFaultData struct {
 // field.
 //
 // See the GridFaultData type for more information on what fields this returns.
-func (c *Client) GetGridFaults() (*[]GridFaultData, error) {
+func (c *Client) GetGridFaults() ([]GridFaultData, error) {
 	c.checkLogin()
 	result := []GridFaultData{}
 	err := c.apiGetJson("system_status/grid_faults", &result)
-	return &result, err
+	return result, err
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix https://github.com/foogod/go-powerwall/issues/1

This PR allows to write

```
 	res, err := client.GetMetersAggregates()
 	if err != nil {
 		return 0, err
 	}
 
-	if o, ok := (*res)[m.usage]; ok {
+	if o, ok := res[m.usage]; ok {
```

for the case of `map` and updates `slice` in the same way.